### PR TITLE
som bug fix

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -94,7 +94,7 @@ end
 
 local function encode_json_base64(data)
     local err
-    -- data, err = encode_json(data)
+    data, err = encode_json(data)
     if not data then
         return nil, err
     end
@@ -388,7 +388,7 @@ local function get(self, key, attr)
             for _, kv in ipairs(res.body.kvs) do
                 kv.key = decode_base64(kv.key)
                 kv.value = decode_base64(kv.value)
-                -- kv.value = decode_json(kv.value)
+                kv.value = decode_json(kv.value)
             end
         end
     end
@@ -521,20 +521,16 @@ local function request_chunk(self, method, host, port, path, opts, timeout)
             return nil, "failed to decode json body: " .. (err or " unkwon")
         end
 
-        if body.error then
-            return nil,encode_json(body)
-        end
-
         if body.result.events then
             for _, event in ipairs(body.result.events) do
                 if event.kv.value then   -- DELETE not have value
                     event.kv.value = decode_base64(event.kv.value)
-                    -- event.kv.value = decode_json(event.kv.value)
+                    event.kv.value = decode_json(event.kv.value)
                 end
                 event.kv.key = decode_base64(event.kv.key)
                 if event.prev_kv then
                     event.prev_kv.value = decode_base64(event.prev_kv.value)
-                    -- event.prev_kv.value = decode_json(event.prev_kv.value)
+                    event.prev_kv.value = decode_json(event.prev_kv.value)
                     event.prev_kv.key = decode_base64(event.prev_kv.key)
                 end
             end
@@ -652,7 +648,7 @@ function _M.get(self, key, opts)
     attr.timeout = opts and opts.timeout
     attr.revision = opts and opts.revision
 
-    return get(self, key,attr)
+    return get(self, key, attr)
 end
 
 function _M.watch(self, key, opts)

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -94,7 +94,7 @@ end
 
 local function encode_json_base64(data)
     local err
-    data, err = encode_json(data)
+    -- data, err = encode_json(data)
     if not data then
         return nil, err
     end
@@ -249,17 +249,17 @@ local function set(self, key, val, attr)
 
     local prev_kv
     if attr.prev_kv then
-        prev_kv = attr.prev_kv and 'true' or 'false'
+        prev_kv = attr.prev_kv and true or false
     end
 
     local ignore_value
     if attr.ignore_value then
-        ignore_value = attr.ignore_value and 'true' or 'false'
+        ignore_value = attr.ignore_value and true or false
     end
 
     local ignore_lease
     if attr.ignore_lease then
-        ignore_lease = attr.ignore_lease and 'true' or 'false'
+        ignore_lease = attr.ignore_lease and true or false
     end
 
     local opts = {
@@ -326,17 +326,17 @@ local function get(self, key, attr)
 
     local serializable
     if attr.serializable then
-        serializable = attr.serializable and 'true' or 'false'
+        serializable = attr.serializable and true or false
     end
 
     local keys_only
     if attr.keys_only then
-        keys_only = attr.keys_only and 'true' or 'false'
+        keys_only = attr.keys_only and true or false
     end
 
     local count_only
     if attr.count_only then
-        count_only = attr.count_only and 'true' or 'false'
+        count_only = attr.count_only and true or false
     end
 
     local min_mod_revision
@@ -388,7 +388,7 @@ local function get(self, key, attr)
             for _, kv in ipairs(res.body.kvs) do
                 kv.key = decode_base64(kv.key)
                 kv.value = decode_base64(kv.value)
-                kv.value = decode_json(kv.value)
+                -- kv.value = decode_json(kv.value)
             end
         end
     end
@@ -406,7 +406,7 @@ local function delete(self, key, attr)
 
     local prev_kv
     if attr.prev_kv then
-        prev_kv = attr.prev_kv and 'true' or 'false'
+        prev_kv = attr.prev_kv and true or false
     end
 
     key = encode_base64(key)
@@ -521,16 +521,20 @@ local function request_chunk(self, method, host, port, path, opts, timeout)
             return nil, "failed to decode json body: " .. (err or " unkwon")
         end
 
+        if body.error then
+            return nil,encode_json(body)
+        end
+
         if body.result.events then
             for _, event in ipairs(body.result.events) do
                 if event.kv.value then   -- DELETE not have value
                     event.kv.value = decode_base64(event.kv.value)
-                    event.kv.value = decode_json(event.kv.value)
+                    -- event.kv.value = decode_json(event.kv.value)
                 end
                 event.kv.key = decode_base64(event.kv.key)
                 if event.prev_kv then
                     event.prev_kv.value = decode_base64(event.prev_kv.value)
-                    event.prev_kv.value = decode_json(event.prev_kv.value)
+                    -- event.prev_kv.value = decode_json(event.prev_kv.value)
                     event.prev_kv.key = decode_base64(event.prev_kv.key)
                 end
             end
@@ -648,7 +652,7 @@ function _M.get(self, key, opts)
     attr.timeout = opts and opts.timeout
     attr.revision = opts and opts.revision
 
-    return get(self, key)
+    return get(self, key,attr)
 end
 
 function _M.watch(self, key, opts)

--- a/t/v3/key.t
+++ b/t/v3/key.t
@@ -56,7 +56,7 @@ __DATA__
             local etcd, err = require "resty.etcd" .new({protocol = "v3"})
             check_res(etcd, err)
 
-            local res, err = etcd:set("/test", "abc")
+            local res, err = etcd:set("/test", "abc", {prev_kv = true})
             check_res(res, err)
 
             local data, err = etcd:get("/test")


### PR DESCRIPTION
1.I comment encode_json/decode_json for the data,because I think the api should only support string.And the encode_json/decode_json shoud be done by the API's users (they may wan't use json to serialization)
2.true or false should be boolean
3.the `get` api lost args attr 
4.the body.result may be nil when etcd server error