### PR TITLE
feat: support original string value via a serializer option

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+std = 'ngx_lua'
+
+ignore={
+    "542"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ env:
 
 install:
   - git clone https://github.com/openresty/test-nginx.git test-nginx
-  - sudo make dev
+    #- sudo make dev
+  - sudo luarocks make rockspec/lua-resty-etcd-master-0.1-0.rockspec
   - wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
   - sudo apt-get -y install software-properties-common
   - sudo add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"

--- a/api_v2.md
+++ b/api_v2.md
@@ -35,6 +35,7 @@ Method
     append this prefix path string to key operation url `'/v2/keys'`.
   - `timeout`: int
     request timeout seconds.
+  - `serializer`: string - serializer type, default `json`, also support `raw` to keep origin string value. 
 
 The client methods returns either a `HTTP Response Entity` or an `error string`.
 

--- a/lib/resty/etcd.lua
+++ b/lib/resty/etcd.lua
@@ -29,12 +29,12 @@ local function etcd_version(opts)
     return ver.body
 end
 
-local function require_package(prefix, package, default)
-    local o, p = pcall(require, prefix .. package)
-    if not o then
-        return require(prefix .. default)
+local function require_package(package, default)
+    local ok, module = pcall(require, package)
+    if not ok then
+        return require(default)
     end
-    return p
+    return module
 end
 
 function _M.new(opts)
@@ -63,8 +63,8 @@ function _M.new(opts)
     end
 
     opts.api_prefix = "/v2"
-    local serializer = opts.serializer or "json"
-    opts.serializer = require_package("resty.etcd.serializers.", serializer, "json")
+    local serializer = typeof.string(opts.serializer) and opts.serializer  or "json"
+    opts.serializer = require_package("resty.etcd.serializers." .. serializer, "resty.etcd.serializers.json")
 
     return etcdv2.new(opts)
 end

--- a/lib/resty/etcd.lua
+++ b/lib/resty/etcd.lua
@@ -30,9 +30,9 @@ end
 local function prequire(prefix, package, default)
     local o, p = pcall(require, prefix .. package)
     if not o then
-         return require(prefix .. default)
-     end
-     return p
+        return require(prefix .. default)
+    end
+    return p
 end
 
 function _M.new(opts)

--- a/lib/resty/etcd.lua
+++ b/lib/resty/etcd.lua
@@ -27,6 +27,13 @@ local function etcd_version(opts)
     return ver.body
 end
 
+local function prequire(prefix, package, default)
+    local o, p = pcall(require, prefix .. package)
+    if not o then
+         return require(prefix .. default)
+     end
+     return p
+end
 
 function _M.new(opts)
     opts = opts or {}
@@ -54,6 +61,8 @@ function _M.new(opts)
     end
 
     opts.api_prefix = "/v2"
+    local serializer = opts.serializer or 'json'
+    opts.serializer = prequire("resty.etcd.serializers.", serializer, 'json')
 
     return etcdv2.new(opts)
 end

--- a/lib/resty/etcd.lua
+++ b/lib/resty/etcd.lua
@@ -29,12 +29,15 @@ local function etcd_version(opts)
     return ver.body
 end
 
-local function require_package(package, default)
-    local ok, module = pcall(require, package)
-    if not ok then
-        return require(default)
+local function require_serializer(serializer_name)
+    if serializer_name then
+        local ok, module = pcall(require, "resty.etcd.serializers." .. serializer_name)
+        if ok then
+            return module
+        end
     end
-    return module
+
+    return require("resty.etcd.serializers.json")
 end
 
 function _M.new(opts)
@@ -63,8 +66,8 @@ function _M.new(opts)
     end
 
     opts.api_prefix = "/v2"
-    local serializer = typeof.string(opts.serializer) and opts.serializer  or "json"
-    opts.serializer = require_package("resty.etcd.serializers." .. serializer, "resty.etcd.serializers.json")
+    local serializer_name = typeof.string(opts.serializer) and opts.serializer
+    opts.serializer = require_serializer(serializer_name)
 
     return etcdv2.new(opts)
 end

--- a/lib/resty/etcd.lua
+++ b/lib/resty/etcd.lua
@@ -1,7 +1,9 @@
-local etcdv2 = require("resty.etcd.v2")
-local etcdv3 = require("resty.etcd.v3")
-local utils  = require("resty.etcd.utils")
-local typeof = require("typeof")
+local etcdv2  = require("resty.etcd.v2")
+local etcdv3  = require("resty.etcd.v3")
+local utils   = require("resty.etcd.utils")
+local typeof  = require("typeof")
+local require = require
+local pcall   = pcall
 local prefix_v3 = {
     ["3.5."] = "/v3",
     ["3.4."] = "/v3",
@@ -27,7 +29,7 @@ local function etcd_version(opts)
     return ver.body
 end
 
-local function prequire(prefix, package, default)
+local function require_package(prefix, package, default)
     local o, p = pcall(require, prefix .. package)
     if not o then
         return require(prefix .. default)
@@ -61,8 +63,8 @@ function _M.new(opts)
     end
 
     opts.api_prefix = "/v2"
-    local serializer = opts.serializer or 'json'
-    opts.serializer = prequire("resty.etcd.serializers.", serializer, 'json')
+    local serializer = opts.serializer or "json"
+    opts.serializer = require_package("resty.etcd.serializers.", serializer, "json")
 
     return etcdv2.new(opts)
 end

--- a/lib/resty/etcd/serializers/json.lua
+++ b/lib/resty/etcd/serializers/json.lua
@@ -1,5 +1,6 @@
 local cjson = require("cjson.safe")
 
+
 return {
     serialize   = cjson.encode,
     deserialize = cjson.decode

--- a/lib/resty/etcd/serializers/json.lua
+++ b/lib/resty/etcd/serializers/json.lua
@@ -1,0 +1,6 @@
+local cjson = require("cjson.safe")
+
+return {
+    serialize   = cjson.encode,
+    deserialize = cjson.decode
+}

--- a/lib/resty/etcd/serializers/raw.lua
+++ b/lib/resty/etcd/serializers/raw.lua
@@ -3,7 +3,7 @@ local type = type
 
 local function raw_encode(v)
     local t = type(v)
-    if v and t ~= 'string' then
+    if t ~= 'string' then
         return nil, 'unsupported type for ' .. t
     end
     return v

--- a/lib/resty/etcd/serializers/raw.lua
+++ b/lib/resty/etcd/serializers/raw.lua
@@ -1,6 +1,10 @@
+local type = type
+
+
 local function raw_encode(v)
-    if v and type(v) ~= 'string' then
-        return nil, "unsupported type for " .. type(v)
+    local t = type(v)
+    if v and t ~= 'string' then
+        return nil, 'unsupported type for ' .. t
     end
     return v
 end
@@ -8,6 +12,7 @@ end
 local function raw_decode(v)
     return v
 end
+
 
 return {
     serialize   = raw_encode,

--- a/lib/resty/etcd/serializers/raw.lua
+++ b/lib/resty/etcd/serializers/raw.lua
@@ -1,0 +1,15 @@
+local function raw_encode(v)
+    if v and type(v) ~= 'string' then
+        return nil, "unsupported type for " .. type(v)
+    end
+    return v
+end
+
+local function raw_decode(v)
+    return v
+end
+
+return {
+    serialize   = raw_encode,
+    deserialize = raw_decode
+}

--- a/lib/resty/etcd/utils.lua
+++ b/lib/resty/etcd/utils.lua
@@ -74,7 +74,7 @@ function _M.has_value(arr, val)
             return key
         end
     end
-    
+
     return false
 end
 

--- a/lib/resty/etcd/v2.lua
+++ b/lib/resty/etcd/v2.lua
@@ -200,10 +200,12 @@ end
 
 local function set(self, key, val, attr)
     local err
-    val, err = self.serializer.serialize(val)
+    if val then
+        val, err = self.serializer.serialize(val)
 
-    if err then
-        return nil, err
+        if err then
+            return nil, err
+        end
     end
 
     local prev_exist

--- a/lib/resty/etcd/v2.lua
+++ b/lib/resty/etcd/v2.lua
@@ -12,8 +12,8 @@ local encode_base64 = ngx.encode_base64
 local require       = require
 local next          = next
 local table         = table
+local decode_json   = cjson.decode
 local INIT_COUNT_RESIZE = 2e8
-local decode_json = cjson.decode
 
 
 local _M = {}

--- a/lib/resty/etcd/v2.lua
+++ b/lib/resty/etcd/v2.lua
@@ -5,7 +5,6 @@ local cjson         = require("cjson.safe")
 local encode_args   = ngx.encode_args
 local setmetatable  = setmetatable
 local clear_tab     = require("table.clear")
-local tostring      = tostring
 local ipairs        = ipairs
 local type          = type
 local utils         = require("resty.etcd.utils")
@@ -14,12 +13,10 @@ local require       = require
 local next          = next
 local table         = table
 local INIT_COUNT_RESIZE = 2e8
+local decode_json = cjson.decode
 
 
-local _M = {
-    decode_json = cjson.decode,
-    encode_json = cjson.encode,
-}
+local _M = {}
 
 
 local mt = { __index = _M }
@@ -49,6 +46,7 @@ function _M.new(opts)
     local http_host = opts.http_host
     local user = opts.user
     local password = opts.password
+    local serializer = opts.serializer
 
     if not typeof.uint(timeout) then
         return nil, 'opts.timeout must be unsigned integer'
@@ -107,7 +105,8 @@ function _M.new(opts)
         is_cluster = #endpoints > 1,
         user = user,
         password = password,
-        endpoints = endpoints
+        endpoints = endpoints,
+        serializer = serializer
     },
     mt)
 
@@ -194,15 +193,16 @@ local function _request(self, method, uri, opts, timeout)
         return res
     end
 
-    res.body = self.decode_json(res.body)
+    res.body = decode_json(res.body)
     return res
 end
 
 
 local function set(self, key, val, attr)
     local err
-    val, err = self.encode_json(val)
-    if not val then
+    val, err = self.serializer.serialize(val)
+
+    if err then
         return nil, err
     end
 
@@ -245,9 +245,9 @@ local function set(self, key, val, attr)
 
     -- get
     if res.status < 300 and res.body.node and not res.body.node.dir then
-        res.body.node.value, err = self.decode_json(res.body.node.value)
+        res.body.node.value, err = self.serializer.deserialize(res.body.node.value)
         if err then
-            utils.log_error("failed to json decode value of node: ", err)
+            utils.log_error("failed to deserialize value of node: ", err)
             return res, err
         end
     end
@@ -269,7 +269,7 @@ local function decode_dir_value(self, body_node)
     for _, node in ipairs(body_node.nodes) do
         local val = node.value
         if type(val) == "string" then
-            node.value, err = self.decode_json(val)
+            node.value, err = self.serializer.deserialize(val)
             if err then
                 utils.log_error("failed to decode json: ", err)
             end
@@ -325,9 +325,9 @@ local function get(self, key, attr)
         if not ok then
             local val = res.body.node.value
             if type(val) == "string" then
-                res.body.node.value, err = self.decode_json(val)
+                res.body.node.value, err = self.serializer.deserialize(val)
                 if err then
-                    utils.log_error("failed to json decode: ", err)
+                    utils.log_error("failed to deserialize: ", err)
                 end
             end
         end
@@ -340,7 +340,7 @@ end
 local function delete(self, key, attr)
     local val, err = attr.prev_value
     if val ~= nil and type(val) ~= "number" then
-        val, err = self.encode_json(val)
+        val, err = self.serializer.serialize(val)
         if not val then
             return nil, err
         end

--- a/lib/resty/etcd/v2.lua
+++ b/lib/resty/etcd/v2.lua
@@ -271,7 +271,7 @@ local function decode_dir_value(self, body_node)
         if type(val) == "string" then
             node.value, err = self.serializer.deserialize(val)
             if err then
-                utils.log_error("failed to decode json: ", err)
+                utils.log_error("failed to deserialize: ", err)
             end
         end
 

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -383,8 +383,8 @@ local function get(self, key, attr)
 
     local res
     res, err = _request_uri(self, "POST",
-                              choose_endpoint(self).full_prefix .. "/kv/range",
-                              opts, attr and attr.timeout or self.timeout)
+                        choose_endpoint(self).full_prefix .. "/kv/range",
+                        opts, attr and attr.timeout or self.timeout)
 
     if res and res.status == 200 then
         if res.body.kvs and tab_nkeys(res.body.kvs) > 0 then

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -381,7 +381,8 @@ local function get(self, key, attr)
         }
     }
 
-    local res, err = _request_uri(self, "POST",
+    local res
+    res, err = _request_uri(self, "POST",
                               choose_endpoint(self).full_prefix .. "/kv/range",
                               opts, attr and attr.timeout or self.timeout)
 
@@ -513,7 +514,7 @@ local function request_chunk(self, method, host, port, path, opts, timeout)
     end
 
     return function()
-        local body, err = res.body_reader()
+        body, err = res.body_reader()
         if not body then
             return nil, err
         end
@@ -664,7 +665,7 @@ end
 function _M.readdir(self, key, opts)
 
     clear_tab(attr)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     attr.range_end = get_range_end(key)
@@ -681,9 +682,9 @@ end
 
 function _M.watchdir(self, key, opts)
     clear_tab(attr)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
-    
+
     attr.range_end = get_range_end(key)
     attr.start_revision  = opts and opts.start_revision
     attr.timeout = opts and opts.timeout
@@ -704,7 +705,7 @@ do
 function _M.set(self, key, val, opts)
 
     clear_tab(attr)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     attr.timeout = opts and opts.timeout
@@ -722,7 +723,7 @@ end
     local failure = {}
 function _M.setnx(self, key, val, opts)
     clear_tab(compare)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     compare[1] = {}
@@ -748,7 +749,7 @@ end
 -- set key-val and ttl if key is exists (update)
 function _M.setx(self, key, val, opts)
     clear_tab(compare)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     compare[1] = {}
@@ -934,7 +935,7 @@ do
     local attr = {}
 function _M.delete(self, key, opts)
     clear_tab(attr)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     attr.timeout = opts and opts.timeout
@@ -945,7 +946,7 @@ end
 
 function _M.rmdir(self, key, opts)
     clear_tab(attr)
-    
+
     key = utils.get_real_key(self.key_prefix, key)
 
     attr.range_end = get_range_end(key)

--- a/rockspec/lua-resty-etcd-master-0.1-0.rockspec
+++ b/rockspec/lua-resty-etcd-master-0.1-0.rockspec
@@ -24,5 +24,7 @@ build = {
     ["resty.etcd.v2"] = "lib/resty/etcd/v2.lua",
     ["resty.etcd.v3"] = "lib/resty/etcd/v3.lua",
     ["resty.etcd.utils"] = "lib/resty/etcd/utils.lua",
+    ["resty.etcd.serializers.json"] = "lib/resty/etcd/serializers/json.lua",
+    ["resty.etcd.serializers.raw"] = "lib/resty/etcd/serializers/raw.lua",
    }
 }

--- a/t/v2/invalid-value.t
+++ b/t/v2/invalid-value.t
@@ -61,13 +61,12 @@ __DATA__
 
             local res, err = etcd:rmdir("/dir", true)
             check_res(res, err)
-
             ngx.say("first")
 
             res, err = etcd:mkdir("/dir")
             check_res(res, err, nil, nil, true)
 
-            etcd.encode_json = function (val)
+            etcd.serializer.serialize = function (val)
                 return val
             end
 
@@ -78,12 +77,15 @@ __DATA__
             res, err = etcd:readdir("/dir")
             check_res(res, err) -- error log
             ngx.say("done readdir")
+
+            local cjson = require("cjson.safe") --recover
+            etcd.serializer.serialize = cjson.encode
         }
     }
 --- request
 GET /t
 --- error_log
-failed to json decode value of node: Expected object key string but found invalid token at character 2
+failed to deserialize value of node: Expected object key string but found invalid token at character 2
 --- response_body
 first
 checked [/dir] is dir.

--- a/t/v2/serializer.t
+++ b/t/v2/serializer.t
@@ -1,0 +1,150 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+
+log_level('warn');
+no_long_string();
+repeat_each(2);
+
+our $HttpConfig = <<'_EOC_';
+    lua_socket_log_errors off;
+    lua_package_path 'lib/?.lua;/usr/local/share/lua/5.3/?.lua;/usr/share/lua/5.1/?.lua;;';
+    init_by_lua_block {
+        function check_res(data, err, val, err_msg, is_dir)
+            if err then
+                ngx.say("err: ", err)
+                return
+            end
+
+            if val then
+                if val ~= data.body.node.value then
+                    ngx.say("failed to check value, got:", data.body.node.value,
+                            ", expect: ", val)
+                    return
+                else
+                    ngx.say("checked val as expect: ", val)
+                end
+            end
+
+            if err_msg then
+                if err_msg ~= data.body.message then
+                    ngx.say("failed to check error msg, got:",
+                            data.body.message, ", expect: ", val)
+                    ngx.exit(200)
+                else
+                    ngx.say("checked error msg as expect: ", err_msg)
+                end
+            end
+
+            if is_dir then
+                if not data.body.node.dir then
+                    ngx.say("failed to check dir, got normal file:",
+                            data.body.node.dir)
+                    ngx.exit(200)
+                else
+                    ngx.say("checked [", data.body.node.key, "] is dir.")
+                end
+            end
+        end
+    }
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: raw string serializer
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson.safe")
+
+            local etcd, err = require("resty.etcd").new( {
+                serializer = "raw"   
+            })
+            check_res(etcd, err)
+
+            local res, err = etcd:rmdir("/dir", true)
+            check_res(res, err)
+
+            res, err = etcd:mkdir("/dir")
+            check_res(res, err, nil, nil, true)
+
+            res, err = etcd:set("/dir/a", 111)
+            check_res(res, err) -- err
+
+            res, err = etcd:set("/dir/b", "")
+            check_res(res, err, "")
+            
+            local s = cjson.encode({a = 1})
+            res, err = etcd:set("/dir/c", s)
+            check_res(res, err)
+
+            res, err = etcd:get("/dir/c")
+            check_res(res, err, s)
+
+            res, err = etcd:readdir("/dir", true)
+            check_res(res, err)
+            for _, v in ipairs(res.body.node.nodes) do
+                if v.value ~= "" and v.value ~= s then
+                    return
+                end
+            end
+            ngx.say("check readdir")
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+checked [/dir] is dir.
+err: unsupported type for number
+checked val as expect: 
+checked val as expect: {"a":1}
+check readdir
+
+
+
+=== TEST 2: json serializer
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd, err = require("resty.etcd").new( {
+                serializer = "json"   
+            })
+            check_res(etcd, err)
+
+            local res, err = etcd:rmdir("/dir", true)
+            check_res(res, err)
+
+            res, err = etcd:mkdir("/dir")
+            check_res(res, err, nil, nil, true)
+
+            etcd, err = require("resty.etcd").new( {
+                serializer = "raw"   
+            })
+            check_res(etcd, err)
+
+            res, err = etcd:set("/dir/a", "")
+            check_res(res, err, "") -- success
+            
+            etcd, err = require("resty.etcd").new( {
+                serializer = "json"   
+            })
+            check_res(etcd, err)
+
+            res, err = etcd:get("/dir/a")
+            check_res(res, err, "") -- error log
+            ngx.say("res.body.node.value: ", res.body.node.value)
+        }
+    }
+--- request
+GET /t
+--- error_log
+failed to deserialize: Expected value but found T_END at character 1
+--- response_body
+checked [/dir] is dir.
+checked val as expect: 
+failed to check value, got:nil, expect: 
+res.body.node.value: nil


### PR DESCRIPTION
Currently, lua-resty-etcd only support for json values and string values not in json format will be discard.  https://github.com/api7/lua-resty-etcd/issues/71 and https://github.com/api7/lua-resty-etcd/issues/57 discussed the requirement for the origin string value stored in etcd. This pull request supports the feature by adding a `serializer` option in `new` method to abstract the serialize and deserialize behavior.