### PR TITLE
fix: remove unnecessary log in etcd v3

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -63,8 +63,6 @@ local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
         http_cli:set_timeout(timeout * 1000)
     end
 
-    utils.log_info('uri:', uri, ' body:', body)
-
     local res
     res, err = http_cli:request_uri(uri, {
         method = method,
@@ -76,8 +74,6 @@ local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
     if err then
         return nil, err
     end
-
-    utils.log_info('res body:', res.body, 'status:', res.status)
 
     if res.status >= 500 then
         return nil, "invalid response code: " .. res.status


### PR DESCRIPTION
Currently every operation in etcd v3 would at least add two info level lines to log file, which could make log file a mess in larger project, especially compared to etcd v2 which would not add a single info lever log line. 

Thus I think it could be a good idea to remove unnecessary log output.