### PR TITLE
bugfix: fixed the typo "verfiy" to "verify".

### DIFF
--- a/api_v2.md
+++ b/api_v2.md
@@ -36,7 +36,7 @@ Method
   - `timeout`: int
     request timeout seconds.
   - `serializer`: string - serializer type, default `json`, also support `raw` to keep origin string value. 
-  - `ssl_verify`: boolean - whether to verify the etcd certificate when originating TLS connection with etcd (if you want to communicate to etcd with TLS connection, use `https` scheme in your `http_host`).
+  - `ssl_verify`: boolean - whether to verify the etcd certificate when originating TLS connection with etcd (if you want to communicate to etcd with TLS connection, use `https` scheme in your `http_host`), default is `true`.
 
 The client methods returns either a `HTTP Response Entity` or an `error string`.
 

--- a/api_v3.md
+++ b/api_v3.md
@@ -40,7 +40,7 @@ Method
   - `api_prefix`: string
     to suit [etcd v3 api gateway](https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_grpc_gateway.md#notes).
     it will autofill by fetching etcd version if this option empty.
-  - `ssl_verify`: boolean - whether to verify the etcd certificate when originating TLS connection with etcd (if you want to communicate to etcd with TLS connection, use `https` scheme in your `http_host`).
+  - `ssl_verify`: boolean - whether to verify the etcd certificate when originating TLS connection with etcd (if you want to communicate to etcd with TLS connection, use `https` scheme in your `http_host`), default is `true.
 
 The client methods returns either a `etcd` object or an `error string`.
 

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -107,7 +107,7 @@ function _M.new(opts)
     local http_host  = opts.http_host
     local user       = opts.user
     local password   = opts.password
-    local ssl_verify = opts.ssl_verfiy
+    local ssl_verify = opts.ssl_verify
 
     if not typeof.uint(timeout) then
         return nil, 'opts.timeout must be unsigned integer'


### PR DESCRIPTION
This bug leads to the TLS certificate verficiation is always enabled.

### Why the test case cannot detect this bug

Since the `etcd.new` first use protocol v2 to fetch the version information where the TLS connection is built normally, and later operations reuse this connection, so the pathological logic in v3 doesn't have a chance to run.