### PR TITLE
feat: add github actions for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Build and Release
+
+on:
+  push:
+    tags: ['v*']
+    branches: [master]
+
+jobs:
+  release:
+    name: Build and Release
+    if: ${{ secrets.LUAROCKS_TOKEN }} != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install luarocks
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      # use ${tag:1} to filter out the heading "v" of "v1.0"
+      - name: Upload to luarocks
+        run: |
+          tag=${{ github.ref }}
+          luarocks upload rockspec/lua-resty-etcd-${tag:1}-0.rockspec --api-key=${{ secrets.LUAROCKS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,36 @@ name: Build and Release
 
 on:
   push:
-    tags: ['v*']
-    branches: [master]
+    tags:
+      - '*'
 
 jobs:
   release:
     name: Build and Release
-    if: ${{ secrets.LUAROCKS_TOKEN }} != null
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install luarocks
+      - name: Install Lua
+        uses: leafo/gh-actions-lua@v8
+
+      - name: Install Luarocks
         uses: leafo/gh-actions-luarocks@v4
+
+      - name: Extract tag name
+        id: tag_env
+        shell: bash
+        run: echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+
+      # use ${tag:1} to filter out the heading "v" of "v1.0" 
+      - name: Upload to luarocks
+        env:
+          LUAROCKS_TOKEN: ${{ secrets.LUAROCKS_TOKEN }}
+        run: |
+          luarocks install dkjson
+          tag=${{ steps.tag_env.outputs.version }}
+          luarocks upload rockspec/lua-resty-etcd-${tag:1}-0.rockspec --api-key=${LUAROCKS_TOKEN}
 
       - name: Create Release
         id: create_release
@@ -23,13 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ steps.tag_env.outputs.version }}
+          release_name: ${{ steps.tag_env.outputs.version }}
           draft: false
           prerelease: false
-
-      # use ${tag:1} to filter out the heading "v" of "v1.0"
-      - name: Upload to luarocks
-        run: |
-          tag=${{ github.ref }}
-          luarocks upload rockspec/lua-resty-etcd-${tag:1}-0.rockspec --api-key=${{ secrets.LUAROCKS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release
+name: Release
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Build and Release
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,8 @@
+## Version Publish
+
+After [#117](https://github.com/api7/lua-resty-etcd/pull/117) got merged, we could publish new version of lua-resty-etcd easily. All you need to do is:
+
+- Create a PR that add the rockspec for the new version.
+- Create a tag with format like 'v1.0'.
+
+The tag would trigger Github Actions to upload to both luarocks and github release.


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Mentioned in #116

I think we could add a Github Actions to automize the version release. It could also work for other repos of api7 that need to upload to luarocks.

The process would be like, whenever we push a new **tag**, it would upload the new release on github and also upload rockspec to luarocks.

**One thing to discuss** is that, do we need to bind the release action to PR, say when we have a release PR tagged with "Release", when it got merged, the action would be triggered to create a tag, and do the rest. 
It would be more convenient, but we need an extra PR when changing release larger change, say from 1.4.3 to 1.5. Ref: https://github.com/anothrNick/github-tag-action

**TODO**
- [x] test on personal repo to make sure it works
- [x] ask @membphis for upload luarocks token