### PR TITLE
doc: fix explanation when timeout set to zero

### DIFF
--- a/api_v3.md
+++ b/api_v3.md
@@ -59,7 +59,7 @@ Please refer to the **etcd API documentaion** at - https://github.com/coreos/etc
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `revision`: (int) revision is the point-in-time of the key-value store to use for the range. If revision is less than or equal to zero, the range is over the newest key-value store. If the revision has been compacted, ErrCompacted is returned as a response.
 
 To get the value for key.
@@ -77,7 +77,7 @@ local res, err = cli:get('/path/to/key')
 * `key`: string value.
 * `val`: the value which can be encoded via JSON.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `lease`: (int) the lease ID to associate with the key in the key-value store.
     * `prev_kv`: (bool) If prev_kv is set, etcd gets the previous key-value pair before changing it. The previous key-value pair will be returned in the put response.
     * `ignore_value`: (bool) If ignore_value is set, etcd updates the key using its current value. Returns an error if the key does not exist. 
@@ -98,7 +98,7 @@ local res, err = cli:set('/path/to/key', 'val', 10)
 * `key`: string value.
 * `val`: the value which can be encoded via JSON.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
 
 To set a key-value pair if that key does not exist.
 
@@ -115,7 +115,7 @@ local res, err = cli:setnx('/path/to/key', 'val', 10)
 * `key`: string value.
 * `val`: the value which can be encoded via JSON.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
 
 To set a key-value pair when that key exists.
 
@@ -131,7 +131,7 @@ local res, err = cli:setx('/path/to/key', 'val', 10)
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `prev_kv`: (bool) If prev_kv is set, etcd gets the previous key-value pairs before deleting it. The previous key-value pairs will be returned in the delete response.
 
 To delete a key-value pair.
@@ -149,7 +149,7 @@ local res, err = cli:delete('/path/to/key')
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `start_revision`: (int) start_revision is an optional revision to watch from (inclusive). No start_revision is "now".
     * `progress_notify`: (bool) progress_notify is set so that the etcd server will periodically send a WatchResponse with no events to the new watcher if there are no recent events. 
     * `filters`: (slice of (enum FilterType {NOPUT = 0;NODELETE = 1;})) filters filter the events at server side before it sends back to the watcher.  
@@ -187,7 +187,7 @@ res = cli:watchcancel(http_cli)
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `revision`: (int) revision is the point-in-time of the key-value store to use for the range. If revision is less than or equal to zero, the range is over the newest key-value store. If the revision has been compacted, ErrCompacted is returned as a response.
     * `limit`: (int) limit is a limit on the number of keys returned for the request. When limit is set to 0, it is treated as no limit. 
     * `sort_order`: (int [SortNone:0, SortAscend:1, SortDescend:2]) sort_order is the order for returned sorted results.  
@@ -211,7 +211,7 @@ local res, err = cli:readdir('/path/to/dir')
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `start_revision`: (int) start_revision is an optional revision to watch from (inclusive). No start_revision is "now".
     * `progress_notify`: (bool) progress_notify is set so that the etcd server will periodically send a WatchResponse with no events to the new watcher if there are no recent events. 
     * `filters`: (slice of [enum FilterType {NOPUT = 0;NODELETE = 1;}]) filters filter the events at server side before it sends back to the watcher.  
@@ -235,7 +235,7 @@ local res, err = cli:watchdir('/path/to/dir')
 
 * `key`: string value.
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
     * `prev_kv`: (bool) If prev_kv is set, etcd gets the previous key-value pairs before deleting it. The previous key-value pairs will be returned in the delete response.
 
 To remove the directory.
@@ -255,7 +255,7 @@ local res, err = cli:rmdir('/path/to/dir')
 * `success`: array of [table](https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_reference_v3.md#message-requestop-etcdserveretcdserverpbrpcproto).
 * `failure`: array of [table](https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_reference_v3.md#message-requestop-etcdserveretcdserverpbrpcproto).
 * `opts`: optional options.
-    * `timeout`: (int) request timeout seconds. set 0 to disable timeout.
+    * `timeout`: (int) request timeout seconds. Set to 0 would use `lua_socket_connect_timeout` as timeout.
 
 Transaction.
 


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Set `timeout = 0` could not disable timeout, it would turn to use the default `lua_socket_connect_timeout` when we do `tcpsock:settimeout(0)`. Could get that from openresty [test case](https://github.com/openresty/lua-nginx-module/blob/master/t/023-rewrite/tcp-socket-timeout.t#L141-L173).

Ref:
1. https://github.com/api7/lua-resty-etcd/blob/master/lib/resty/etcd/v3.lua#L67
2. https://github.com/openresty/lua-nginx-module/blob/master/t/023-rewrite/tcp-socket-timeout.t#L141-L173