### PR TITLE
fix: should fail fast when etcd returns error

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -82,7 +82,7 @@ local function _request_uri(self, endpoint, method, uri, opts, timeout, ignore_a
         if health_check.conf ~= nil then
             health_check.report_failure(endpoint.http_host)
         end
-        return nil, err
+        return nil, endpoint.http_host .. ": " .. err
     end
 
     if res.status >= 500 then
@@ -604,7 +604,7 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
         if health_check.conf ~= nil then
             health_check.report_failure(endpoint.http_host)
         end
-        return nil, err
+        return nil, endpoint.http_host .. ": " .. err
     end
 
     local res
@@ -647,7 +647,7 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
             if health_check.conf ~= nil then
                 health_check.report_failure(endpoint.http_host)
             end
-            return nil, body.error.http_status .. ": " .. endpoint.http_host
+            return nil, endpoint.http_host .. ": " .. body.error.http_status
         end
 
         if body.result.events then

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -647,6 +647,7 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
             if health_check.conf ~= nil then
                 health_check.report_failure(endpoint.http_host)
             end
+            return nil, body.error.http_status .. ": " .. endpoint.http_host
         end
 
         if body.result.events then

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -85,7 +85,7 @@ local function _request_uri(self, endpoint, method, uri, opts, timeout, ignore_a
         return nil, endpoint.http_host .. ": " .. err
     end
 
-    if res.status >= 500 then
+    if res.status >= 400 then
         if health_check.conf ~= nil then
             health_check.report_failure(endpoint.http_host)
         end
@@ -643,7 +643,7 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
         body, err = decode_json(body)
         if not body then
             return nil, "failed to decode json body: " .. (err or " unkwon")
-        elseif body.error and body.error.http_code >= 500 then
+        elseif body.error and body.error.http_code >= 400 then
             if health_check.conf ~= nil then
                 health_check.report_failure(endpoint.http_host)
             end

--- a/t/v3/auth.t
+++ b/t/v3/auth.t
@@ -64,7 +64,7 @@ __DATA__
                 password = 'abc123',
                 timeout = 3,
                 http_host = {
-                    "http://127.0.0.1:12379", 
+                    "http://127.0.0.1:12379",
                 },
             })
             check_res(etcd, err)
@@ -118,7 +118,7 @@ uri: http://127.0.0.1:12379/v3/kv/deleterange, timeout: 3
                 password = '123',
                 timeout = 3,
                 http_host = {
-                    "http://127.0.0.1:12379", 
+                    "http://127.0.0.1:12379",
                 },
             })
             check_res(etcd, err)

--- a/t/v3/health_check.t
+++ b/t/v3/health_check.t
@@ -192,6 +192,7 @@ http://127.0.0.1:42379: connection refused
             local body_chunk_fun, err = etcd:watch("/trigger_unhealthy")
             if not body_chunk_fun then
                 ngx.say(err)
+            end
         }
     }
 --- request
@@ -200,6 +201,7 @@ GET /t
 qr/update endpoint: http:\/\/127.0.0.1:42379 to unhealthy/
 --- response_body
 http://127.0.0.1:42379: connection refused
+
 
 
 === TEST 6: fault count


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

When running etcd, if etcd node is disconnected, error log would contains
```
2021/02/27 15:30:19 [error] 49#49: *114289 [lua] config_etcd.lua:566: failed to fetch data from etcd: /usr/local/apisix//deps/share/lua/5.1/resty/etcd/v3.lua:593: attempt to index field 'result' (a nil value)
stack traceback:
/usr/local/apisix//deps/share/lua/5.1/resty/etcd/v3.lua:593: in function 'res_func'
/usr/local/apisix/apisix/core/config_etcd.lua:125: in function 'waitdir'
/usr/local/apisix/apisix/core/config_etcd.lua:305: in function 'sync_data'
/usr/local/apisix/apisix/core/config_etcd.lua:540: in function </usr/local/apisix/apisix/core/config_etcd.lua:530>
[C]: in function 'xpcall'
/usr/local/apisix/apisix/core/config_etcd.lua:530: in function </usr/local/apisix/apisix/core/config_etcd.lua:521>,  etcd key: /apisix/global_rules, context: ngx.timer
```

This PR would fix this error and returns corresponding error inforamation