### PR TITLE
fix: get random endpoint from choose_endpoint

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -215,7 +215,13 @@ local function choose_endpoint(self)
     end
 
     if health_check.conf ~= nil then
-        for _, endpoint in ipairs(endpoints) do
+        local shuffled_endpoints = {}
+        for _, v in ipairs(endpoints) do
+            local pos = random(1, #shuffled_endpoints+1)
+            tab_insert(shuffled_endpoints, pos, v)
+        end
+
+        for _, endpoint in ipairs(shuffled_endpoints) do
             if health_check.get_target_status(endpoint.http_host) then
                 return endpoint
             end

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -230,7 +230,8 @@ local function choose_endpoint(self)
         return nil, "has no healthy etcd endpoint available"
     end
 
-    self.init_count = (self.init_count or 0) + 1
+    local init_pos = random(1, endpoints_len)
+    self.init_count = (self.init_count or 0) + init_pos
     local pos = self.init_count % endpoints_len + 1
     if self.init_count >= INIT_COUNT_RESIZE then
         self.init_count = 0


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

So when the first endpoint is unhealthy, not all processes gonna hit it.