### PR TITLE
feat: support retry in health-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ t/servroot
 utils/lj-releng
 [\.]*
 !.github/
+*.etcd
+*.log

--- a/health_check.md
+++ b/health_check.md
@@ -20,7 +20,7 @@ Initializes the health check object, overiding default params with the given one
 
 `syntax: health_check.report_failure(etcd_host)`
 
-Reports a health failure which will count against the number of occurrences required to make a target "fail". 
+Reports a health failure which will count against the number of occurrences required to make a target "fail".
 
 ###  get_target_status
 
@@ -35,6 +35,7 @@ Get the current status of the target.
 | shm_name     | string  | required    |         | the declarative `lua_shared_dict` is used to store the health status of endpoints. |
 | fail_timeout | integer | optional    | 10s     | sets the time during which the specified number of unsuccessful attempts to communicate with the endpoint should happen to marker the endpoint unavailable, and also sets the period of time the endpoint will be marked unavailable. |
 | max_fails    | integer | optional    | 1       | sets the number of failed attempts that must occur during the `fail_timeout` period for the endpoint to be marked unavailable. |
+| retry        | bool    | optional    | false   | automatically retry another endpoint when operations failed. |
 
 lua example:
 
@@ -43,16 +44,17 @@ local health_check, err = require("resty.etcd.health_check").init({
     shm_name = "healthcheck_shm",
     fail_timeout = 10,
     max_fails = 1,
+    retry = false,
 })
 ```
 
-In a `fail_timeout`, if there are `max_fails` consecutive failures, the endpoint is marked as unhealthy,  the unhealthy endpoint will not be choosed to connect for a `fail_timeout` time in the future. 
+In a `fail_timeout`, if there are `max_fails` consecutive failures, the endpoint is marked as unhealthy,  the unhealthy endpoint will not be choosed to connect for a `fail_timeout` time in the future.
 
 Health check mechanism would switch endpoint only when the previously choosed endpoint is marked as unhealthy.
 
 The failure counter and health status of each etcd endpoint are shared across workers and by different etcd clients.
 
-Also note that the `fail_timeout` and `max_fails` of the health check cannot be changed once it has been created.
+Also note that the `fail_timeout`, `max_fails` and `retry` of the health check cannot be changed once it has been created.
 
 ##  Synopsis
 
@@ -69,12 +71,13 @@ http {
                     shm_name = "healthcheck_shm",
                     fail_timeout = 10,
                     max_fails = 1,
+                    retry = false,
                 })
 
                 local etcd, err = require("resty.etcd").new({
                     protocol = "v3",
                     http_host = {
-                        "http://127.0.0.1:12379", 
+                        "http://127.0.0.1:12379",
                         "http://127.0.0.1:22379",
                         "http://127.0.0.1:32379",
                     },

--- a/lib/resty/etcd/health_check.lua
+++ b/lib/resty/etcd/health_check.lua
@@ -77,6 +77,7 @@ function _M.init(opts)
         conf.shm_name = opts.shm_name
         conf.fail_timeout = opts.fail_timeout or 10    -- 10 sec
         conf.max_fails = opts.max_fails or 1
+        conf.retry = opts.retry or false
         _M.conf = conf
         return _M, nil
     end

--- a/lib/resty/etcd/utils.lua
+++ b/lib/resty/etcd/utils.lua
@@ -86,6 +86,10 @@ function _M.has_value(arr, val)
     return false
 end
 
+function _M.starts_with(str, start)
+    return str:sub(1, #start) == start
+end
+
 local ngx_log = ngx.log
 local ngx_ERR = ngx.ERR
 local ngx_INFO = ngx.INFO

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -49,7 +49,7 @@ local function choose_endpoint(self)
     end
 
     self.init_count = (self.init_count or 0)
-    local pos = self.init_count % endpoints_len
+    local pos = self.init_count % endpoints_len + 1
     if self.init_count >= INIT_COUNT_RESIZE then
         self.init_count = 0
     end
@@ -144,7 +144,7 @@ local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
             return nil, err
         end
     else
-        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
+        local max_retry = #self.endpoints * health_check.conf.max_fails - 1
         for _ = 1, max_retry do
             res, err = http_request_uri(self, http_cli, method, uri, body, headers, keepalive)
             if err then
@@ -627,7 +627,7 @@ local function request_chunk(self, method, path, opts, timeout)
             return nil, err
         end
     else
-        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
+        local max_retry = #self.endpoints * health_check.conf.max_fails - 1
         for _ = 1, max_retry do
             endpoint, err = http_request_chunk(self, http_cli)
             if err then

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -613,7 +613,6 @@ local function request_chunk(self, method, path, opts, timeout)
         return nil, err
     end
 
-    local ok, _
     if timeout then
         _, err = http_cli:set_timeout(timeout * 1000)
         if err then

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -48,7 +48,7 @@ local function choose_endpoint(self)
         return nil, "has no healthy etcd endpoint available"
     end
 
-    self.init_count = (self.init_count or 0)
+    self.init_count = (self.init_count or -1) + 1
     local pos = self.init_count % endpoints_len + 1
     if self.init_count >= INIT_COUNT_RESIZE then
         self.init_count = 0

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -31,7 +31,34 @@ local mt = { __index = _M }
 -- define local refresh function variable
 local refresh_jwt_token
 
-local function _request_uri(self, endpoint, method, uri, opts, timeout, ignore_auth)
+
+local function choose_endpoint(self)
+    local endpoints = self.endpoints
+    local endpoints_len = #endpoints
+    if endpoints_len == 1 then
+        return endpoints[1]
+    end
+
+    if health_check.conf ~= nil then
+        for _, endpoint in ipairs(endpoints) do
+            if health_check.get_target_status(endpoint.http_host) then
+                return endpoint
+            end
+        end
+        return nil, "has no healthy etcd endpoint available"
+    end
+
+    self.init_count = (self.init_count or 0) + 1
+    local pos = self.init_count % endpoints_len + 1
+    if self.init_count >= INIT_COUNT_RESIZE then
+        self.init_count = 0
+    end
+
+    return endpoints[pos]
+end
+
+
+local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
     utils.log_info("v3 request uri: ", uri, ", timeout: ", timeout)
 
     local body
@@ -67,30 +94,68 @@ local function _request_uri(self, endpoint, method, uri, opts, timeout, ignore_a
         http_cli:set_timeout(timeout * 1000)
     end
 
-    local res
-    res, err = http_cli:request_uri(uri, {
-        method = method,
-        body = body,
-        headers = headers,
-        keepalive = keepalive,
-        ssl_verify = self.ssl_verify,
-        ssl_cert_path = self.ssl_cert_path,
-        ssl_key_path = self.ssl_key_path,
-    })
-
-    if err then
-        if health_check.conf ~= nil then
-            health_check.report_failure(endpoint.http_host)
-            err = endpoint.http_host .. ": " .. err
+    local function http_request()
+        local endpoint
+        endpoint, err = choose_endpoint(self)
+        if not endpoint then
+            return nil, err
         end
-        return nil, err
+
+        local full_uri
+        if utils.starts_with(uri, "/version") or utils.starts_with(uri, "/v2") then
+            full_uri = endpoint.http_host .. uri
+        else
+            full_uri = endpoint.full_prefix .. uri
+        end
+
+        local res
+        res, err = http_cli:request_uri(full_uri, {
+            method = method,
+            body = body,
+            headers = headers,
+            keepalive = keepalive,
+            ssl_verify = self.ssl_verify,
+            ssl_cert_path = self.ssl_cert_path,
+            ssl_key_path = self.ssl_key_path,
+        })
+
+        if err then
+            if health_check.conf ~= nil then
+                health_check.report_failure(endpoint.http_host)
+                err = endpoint.http_host .. ": " .. err
+            end
+            return nil, err
+        end
+
+        if res.status >= 500 then
+            if health_check.conf ~= nil then
+                health_check.report_failure(endpoint.http_host)
+            end
+            return nil, "invalid response code: " .. res.status
+        end
+
+        return res
     end
 
-    if res.status >= 500 then
-        if health_check.conf ~= nil then
-            health_check.report_failure(endpoint.http_host)
+    local res
+    if health_check.conf == nil or not health_check.conf.retry then
+        res, err = http_request()
+        if err then
+            return nil, err
         end
-        return nil, "invalid response code: " .. res.status
+    else
+        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
+        for _ = 1, max_retry do
+            res, err = http_request()
+            if err then
+                utils.log_warn(err .. ". Retrying")
+                if err == "has no healthy etcd endpoint available" then
+                    return nil, err
+                end
+            else
+                break
+            end
+        end
     end
 
     if not typeof.string(res.body) then
@@ -207,33 +272,6 @@ function _M.new(opts)
 end
 
 
-local function choose_endpoint(self)
-    local endpoints = self.endpoints
-    local endpoints_len = #endpoints
-    if endpoints_len == 1 then
-        return endpoints[1]
-    end
-
-    if health_check.conf ~= nil then
-        for _, endpoint in ipairs(endpoints) do
-            if health_check.get_target_status(endpoint.http_host) then
-                return endpoint
-            end
-        end
-        utils.log_warn("has no healthy etcd endpoint available")
-        return nil, "has no healthy etcd endpoint available"
-    end
-
-    self.init_count = (self.init_count or 0) + 1
-    local pos = self.init_count % endpoints_len + 1
-    if self.init_count >= INIT_COUNT_RESIZE then
-        self.init_count = 0
-    end
-
-    return endpoints[pos]
-end
-
-
 local function wake_up_everyone(self)
     local count = -self.sema:count()
     if count > 0 then
@@ -276,15 +314,8 @@ function refresh_jwt_token(self, timeout)
         }
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    local res
-    res, err = _request_uri(self, endpoint, 'POST',
-                                  endpoint.full_prefix .. "/auth/authenticate",
-                                  opts, timeout, true)
+    local res, err
+    res, err = _request_uri(self, 'POST', "/auth/authenticate", opts, timeout, true)
     self.requesting_token = false
 
     if err then
@@ -356,16 +387,8 @@ local function set(self, key, val, attr)
         }
     }
 
-    local endpoint
-    endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
     local res
-    res, err = _request_uri(self, endpoint, 'POST',
-                        endpoint.full_prefix .. "/kv/put",
-                        opts, self.timeout)
+    res, err = _request_uri(self, 'POST', "/kv/put", opts, self.timeout)
     if err then
         return nil, err
     end
@@ -469,16 +492,8 @@ local function get(self, key, attr)
         }
     }
 
-    local endpoint
-    endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
     local res
-    res, err = _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/kv/range",
-                        opts, attr and attr.timeout or self.timeout)
+    res, err = _request_uri(self, "POST", "/kv/range", opts, attr and attr.timeout or self.timeout)
 
     if res and res.status == 200 then
         if res.body.kvs and tab_nkeys(res.body.kvs) > 0 then
@@ -516,14 +531,8 @@ local function delete(self, key, attr)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
 
-    return _request_uri(self, endpoint, "POST",
-                    endpoint.full_prefix .. "/kv/deleterange",
-                    opts, self.timeout)
+    return _request_uri(self, "POST", "/kv/deleterange", opts, self.timeout)
 end
 
 local function txn(self, opts_arg, compare, success, failure)
@@ -544,18 +553,11 @@ local function txn(self, opts_arg, compare, success, failure)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    return _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/kv/txn",
-                        opts, timeout or self.timeout)
+    return _request_uri(self, "POST", "/kv/txn", opts, timeout or self.timeout)
 end
 
 
-local function request_chunk(self, endpoint, method, scheme, host, port, path, opts, timeout)
+local function request_chunk(self, method, path, opts, timeout)
     local body, err, _
     if opts and opts.body and tab_nkeys(opts.body) > 0 then
         body, err = encode_json(opts.body)
@@ -593,25 +595,56 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
         end
     end
 
-    ok, err = http_cli:connect({
-        scheme = scheme,
-        host = host,
-        port = port,
-        ssl_verify = self.ssl_verify,
-        ssl_cert_path = self.ssl_cert_path,
-        ssl_key_path = self.ssl_key_path,
-    })
-    if not ok then
-        if health_check.conf ~= nil then
-            health_check.report_failure(endpoint.http_host)
+    local function http_request()
+        local endpoint
+        endpoint, err = choose_endpoint(self)
+        if not endpoint then
+            return nil, err
         end
-        return nil, endpoint.http_host .. ": " .. err
+
+        ok, err = http_cli:connect({
+            scheme = endpoint.scheme,
+            host = endpoint.host,
+            port = endpoint.port,
+            ssl_verify = self.ssl_verify,
+            ssl_cert_path = self.ssl_cert_path,
+            ssl_key_path = self.ssl_key_path,
+        })
+        if not ok then
+            if health_check.conf ~= nil then
+                health_check.report_failure(endpoint.http_host)
+            end
+            return nil, endpoint.http_host .. ": " .. err
+        end
+
+        return endpoint, err
+    end
+
+    local endpoint
+    if health_check.conf == nil or not health_check.conf.retry then
+        endpoint, err = http_request()
+        if err then
+            return nil, err
+        end
+    else
+        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
+        for _ = 1, max_retry do
+            endpoint, err = http_request()
+            if err then
+                utils.log_warn(err .. ". Retrying")
+                if err == "has no healthy etcd endpoint available" then
+                    return nil, err
+                end
+            else
+                break
+            end
+        end
     end
 
     local res
     res, err = http_cli:request({
         method  = method,
-        path    = path,
+        path    = endpoint.api_prefix .. path,
         body    = body,
         query   = query,
         headers = headers,
@@ -646,6 +679,8 @@ local function request_chunk(self, endpoint, method, scheme, host, port, path, o
             return nil, "failed to decode json body: " .. (err or " unkwon")
         elseif body.error and body.error.http_code >= 500 then
             if health_check.conf ~= nil then
+                -- health_check retry should do nothing here
+                -- and let connection broke to create a new one
                 health_check.report_failure(endpoint.http_host)
             end
             return nil, endpoint.http_host .. ": " .. body.error.http_status
@@ -762,12 +797,8 @@ local function watch(self, key, attr)
     end
 
     local callback_fun, http_cli
-    callback_fun, err, http_cli = request_chunk(self, endpoint, 'POST',
-                                endpoint.scheme,
-                                endpoint.host,
-                                endpoint.port,
-                                endpoint.api_prefix .. '/watch', opts,
-                                attr.timeout or self.timeout)
+    callback_fun, err, http_cli = request_chunk(self, 'POST', '/watch',
+                                                opts, attr.timeout or self.timeout)
     if not callback_fun then
         return nil, err
     end
@@ -993,13 +1024,7 @@ function _M.grant(self, ttl, id)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    return _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/lease/grant", opts)
+    return _request_uri(self, "POST", "/lease/grant", opts)
 end
 
 function _M.revoke(self, id)
@@ -1013,13 +1038,7 @@ function _M.revoke(self, id)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    return _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/kv/lease/revoke", opts)
+    return _request_uri(self, "POST", "/kv/lease/revoke", opts)
 end
 
 function _M.keepalive(self, id)
@@ -1033,13 +1052,7 @@ function _M.keepalive(self, id)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    return _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/lease/keepalive", opts)
+    return _request_uri(self, "POST", "/lease/keepalive", opts)
 end
 
 function _M.timetolive(self, id, keys)
@@ -1055,14 +1068,8 @@ function _M.timetolive(self, id, keys)
         },
     }
 
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-
-    local res
-    res, err = _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/kv/lease/timetolive", opts)
+    local res, err
+    res, err = _request_uri(self, "POST", "/kv/lease/timetolive", opts)
 
     if res and res.status == 200 then
         if res.body.keys and tab_nkeys(res.body.keys) > 0 then
@@ -1076,55 +1083,26 @@ function _M.timetolive(self, id, keys)
 end
 
 function _M.leases(self)
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-    return _request_uri(self, endpoint, "POST",
-                        endpoint.full_prefix .. "/lease/leases")
+    return _request_uri(self, "POST", "/lease/leases")
 end
 
 
 -- /version
 function _M.version(self)
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-    return _request_uri(self, endpoint, "GET",
-                        endpoint.http_host .. "/version",
-                        nil, self.timeout)
+    return _request_uri(self, "GET", "/version", nil, self.timeout)
 end
 
 -- /stats
 function _M.stats_leader(self)
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-    return _request_uri(self, endpoint, "GET",
-                        endpoint.http_host .. "/v2/stats/leader",
-                        nil, self.timeout)
+    return _request_uri(self, "GET", "/v2/stats/leader", nil, self.timeout)
 end
 
 function _M.stats_self(self)
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-    return _request_uri(self, endpoint, "GET",
-                        endpoint.http_host .. "/v2/stats/self",
-                        nil, self.timeout)
+    return _request_uri(self, "GET", "/v2/stats/self", nil, self.timeout)
 end
 
 function _M.stats_store(self)
-    local endpoint, err = choose_endpoint(self)
-    if not endpoint then
-        return nil, err
-    end
-    return _request_uri(self, endpoint, "GET",
-                        endpoint.http_host .. "/v2/stats/store",
-                        nil, self.timeout)
+    return _request_uri(self, "GET", "/v2/stats/store", nil, self.timeout)
 end
 
 

--- a/t/v3/auth.t
+++ b/t/v3/auth.t
@@ -97,13 +97,13 @@ ok
 --- grep_error_log eval
 qr/uri: .+, timeout: \d+/
 --- grep_error_log_out
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:12379/v3/auth/authenticate, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/deleterange, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/deleterange, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/deleterange, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /auth/authenticate, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /kv/deleterange, timeout: 3
+uri: /kv/deleterange, timeout: 3
+uri: /kv/deleterange, timeout: 3
 
 
 
@@ -146,10 +146,10 @@ ok
 --- grep_error_log eval
 qr/(uri: .+, timeout: \d+|v3 refresh jwt last err: [^,]+|authenticate refresh token fail)/
 --- grep_error_log_out
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:12379/v3/auth/authenticate, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:12379/v3/kv/put, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /auth/authenticate, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /kv/put, timeout: 3
 authenticate refresh token fail
 v3 refresh jwt last err: authenticate refresh token fail
 authenticate refresh token fail
@@ -202,10 +202,10 @@ ok
 --- grep_error_log eval
 qr/(uri: .+, timeout: \d+|v3 refresh jwt last err: [^,]+|connection refused)/
 --- grep_error_log_out
-uri: http://127.0.0.1:1997/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:1997/v3/auth/authenticate, timeout: 3
-uri: http://127.0.0.1:1997/v3/kv/put, timeout: 3
-uri: http://127.0.0.1:1997/v3/kv/put, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /auth/authenticate, timeout: 3
+uri: /kv/put, timeout: 3
+uri: /kv/put, timeout: 3
 connection refused
 v3 refresh jwt last err: connection refused
 connection refused

--- a/t/v3/health_check.t
+++ b/t/v3/health_check.t
@@ -364,8 +364,6 @@ GET /t
 has no healthy etcd endpoint available
 --- no_error_log
 [error]
---- error_log eval
-qr/has no healthy etcd endpoint available/
 
 
 

--- a/t/v3/health_check.t
+++ b/t/v3/health_check.t
@@ -471,3 +471,98 @@ GET /t
 1
 --- error_log eval
 qr/update endpoint: http:\/\/localhost:1984 to unhealthy/
+
+
+
+=== TEST 12: test if retry works for request_uri
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local health_check, err = require "resty.etcd.health_check" .init({
+                shm_name = "etcd_cluster_health_check",
+                fail_timeout = 10,
+                max_fails = 3,
+                retry = true,
+            })
+
+            local etcd, err = require "resty.etcd" .new({
+                protocol = "v3",
+                http_host = {
+                    "http://127.0.0.1:42379",
+                    "http://127.0.0.1:22379",
+                    "http://127.0.0.1:32379",
+                },
+                user = 'root',
+                password = 'abc123',
+            })
+
+            local res, err = etcd:set("/trigger_unhealthy", "abc")
+            check_res(res, err)
+            local res, err = etcd:get("/trigger_unhealthy")
+            check_res(res, err, "abc")
+        }
+    }
+--- request
+GET /t
+--- error_log eval
+qr/update endpoint: http:\/\/127.0.0.1:42379 to unhealthy/
+--- response_body
+checked val as expect: abc
+
+
+=== TEST 13: test if retry works for request_chunk
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local health_check, err = require "resty.etcd.health_check" .init({
+                shm_name = "etcd_cluster_health_check",
+                fail_timeout = 10,
+                max_fails = 3,
+                retry = true,
+            })
+
+            local etcd, err = require "resty.etcd" .new({
+                protocol = "v3",
+                http_host = {
+                    "http://127.0.0.1:42379",
+                    "http://127.0.0.1:22379",
+                    "http://127.0.0.1:32379",
+                },
+                user = 'root',
+                password = 'abc123',
+            })
+
+            local body_chunk_fun, err = etcd:watch("/trigger_unhealthy", {timeout = 0.5})
+            check_res(body_chunk_fun, err)
+
+            ngx.timer.at(0.1, function ()
+                etcd:set("/trigger_unhealthy", "abc")
+            end)
+
+            local idx = 0
+            while true do
+                local chunk, err = body_chunk_fun()
+
+                if not chunk then
+                    if err then
+                        ngx.say(err)
+                    end
+                    break
+                end
+
+                idx = idx + 1
+                ngx.say(idx, ": ", require("cjson").encode(chunk.result))
+            end
+        }
+    }
+--- request
+GET /t
+--- error_log eval
+qr/update endpoint: http:\/\/127.0.0.1:42379 to unhealthy/
+--- response_body_like eval
+qr/1:.*"created":true.*
+2:.*"value":"abc".*
+timeout/
+--- timeout: 5


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

1. add option `retry` in health-check. When it is enabled, operations would keep trying the same endpoint till unhealthy, and then other endpoints, until success or no endpoints healthy. So we could ensure each operation would send to etcd with best effort.
Currently not support for `read_watch` since it would be better to close the original connection and create a new watch with a new endpoint.
2. move `choose_enpoint` into `request_uri` and `request_chunk` so it could find alternative endpoint easier