### PR TITLE
fix: etcd should add another retry when no endpoints healthy

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -35,9 +35,6 @@ local refresh_jwt_token
 local function choose_endpoint(self)
     local endpoints = self.endpoints
     local endpoints_len = #endpoints
-    if endpoints_len == 1 then
-        return endpoints[1]
-    end
 
     if health_check.conf ~= nil then
         for _, endpoint in ipairs(endpoints) do

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -144,7 +144,7 @@ local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
             return nil, err
         end
     else
-        local max_retry = #self.endpoints * health_check.conf.max_fails - 1
+        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
         for _ = 1, max_retry do
             res, err = http_request_uri(self, http_cli, method, uri, body, headers, keepalive)
             if err then
@@ -627,7 +627,7 @@ local function request_chunk(self, method, path, opts, timeout)
             return nil, err
         end
     else
-        local max_retry = #self.endpoints * health_check.conf.max_fails - 1
+        local max_retry = #self.endpoints * health_check.conf.max_fails + 1
         for _ = 1, max_retry do
             endpoint, err = http_request_chunk(self, http_cli)
             if err then


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Just found two bugs related to #131. 
- When no endpoints healthy, we need `#self.endpoints * health_check.conf.max_fails` times to make all endpoints status changed to unhealthy, and it would be better to retry another time to return the error `has no healthy etcd endpoint available` so users could better deal with the result.
- When only one etcd endpoint is set, we still need to enable health_check, to keep "ERR_NO_ETCD_ENDPOINT_AVAILABLE" the same.