### PR TITLE
chore: remove unnecessary log for health check retry

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -145,10 +145,10 @@ local function _request_uri(self, method, uri, opts, timeout, ignore_auth)
         for _ = 1, max_retry do
             res, err = http_request_uri(self, http_cli, method, uri, body, headers, keepalive)
             if err then
-                utils.log_warn(err .. ". Retrying")
                 if err == "has no healthy etcd endpoint available" then
                     return nil, err
                 end
+                utils.log_warn(err .. ". Retrying")
             else
                 break
             end


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Ref #133

Currently we got
```
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23790: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23790: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] health_check.lua:63: report_failure(): update endpoint: http://127.0.0.1:23790 to unhealthy, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23790: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23791: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23791: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] health_check.lua:63: report_failure(): update endpoint: http://127.0.0.1:23791 to unhealthy, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23791: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23792: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23792: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] health_check.lua:63: report_failure(): update endpoint: http://127.0.0.1:23792 to unhealthy, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): http://127.0.0.1:23792: connection refused. Retrying, context: ngx.timer
2021/06/28 16:44:17 [warn] 18038#18038: *5482 [lua] v3.lua:148: grant(): has no healthy etcd endpoint available. Retrying, context: ngx.timer
```

Remove the last line since we only need to return the error `has no healthy etcd endpoint available`. No need to print it out duplicatedly.