### PR TITLE
ci: refine auto release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,10 @@ name: Release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - "master"
+    paths:
+      - 'rockspec/**'
 
 jobs:
   release:
@@ -19,27 +21,34 @@ jobs:
       - name: Install Luarocks
         uses: leafo/gh-actions-luarocks@v4
 
-      - name: Extract tag name
-        id: tag_env
+      - name: Extract release name
+        id: release_env
         shell: bash
-        run: echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+        run: |
+          title="${{ github.event.head_commit.message }}"
+          re="^feat: release v*(\S+)"
+          if [[ $title =~ $re ]]; then
+              v=v${BASH_REMATCH[1]}
+              echo "##[set-output name=version;]${v}"
+              echo "##[set-output name=version_withou_v;]${BASH_REMATCH[1]}"
+          else
+              echo "commit format is not correct"
+              exit 1
+          fi
 
-      # use ${tag:1} to filter out the heading "v" of "v1.0" 
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.release_env.outputs.version }}
+          release_name: ${{ steps.release_env.outputs.version }}
+          draft: false
+          prerelease: false
+
       - name: Upload to luarocks
         env:
           LUAROCKS_TOKEN: ${{ secrets.LUAROCKS_TOKEN }}
         run: |
           luarocks install dkjson
-          tag=${{ steps.tag_env.outputs.version }}
-          luarocks upload rockspec/lua-resty-etcd-${tag:1}-0.rockspec --api-key=${LUAROCKS_TOKEN}
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.tag_env.outputs.version }}
-          release_name: ${{ steps.tag_env.outputs.version }}
-          draft: false
-          prerelease: false
+          luarocks upload rockspec/lua-resty-etcd-${{ steps.release_env.outputs.version_withou_v }}-0.rockspec --api-key=${LUAROCKS_TOKEN}

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -2,6 +2,6 @@
 
 After [#137](https://github.com/api7/lua-resty-etcd/pull/137) got merged, we could publish new version of lua-resty-etcd easily. All you need to do is:
 
-- Create a PR following the format `feat: release VERSION`, where `VERSION` should be the version used in the rockspec name, like `1.0` for `lua-resty-etcd-1.0-0.rockspec`.
+- Create the release PR following the format `feat: release VERSION`, where `VERSION` should be the version used in the rockspec name, like `1.0` for `lua-resty-etcd-1.0-0.rockspec`.
 
 When the PR got merged, it would trigger Github Actions to upload to both github release and luarocks.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,8 +1,7 @@
 ## Version Publish
 
-After [#117](https://github.com/api7/lua-resty-etcd/pull/117) got merged, we could publish new version of lua-resty-etcd easily. All you need to do is:
+After [#137](https://github.com/api7/lua-resty-etcd/pull/137) got merged, we could publish new version of lua-resty-etcd easily. All you need to do is:
 
-- Create a PR that add the rockspec for the new version.
-- Create a tag with format like 'v1.0'.
+- Create a PR following the format `feat: release VERSION`, where `VERSION` should be the version used in the rockspec name, like `1.0` for `lua-resty-etcd-1.0-0.rockspec`.
 
-The tag would trigger Github Actions to upload to both luarocks and github release.
+When the PR got merged, it would trigger Github Actions to upload to both github release and luarocks.


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

After #117, to trigger auto release, we still need a maintainer to create a tag. To simplify the steps (so no need to ask membphis each time 😿), try to move trigger from tag to merged PR with changes in rockspec and also title prefix in `feat: release`.

Tested in https://github.com/Yiyiyimu/GithubActionsTest/actions/runs/983995083 and works as expected