### PR TITLE
chore(ci): fetch apisix-openresty has been renamed to apisix-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           git clone https://github.com/openresty/test-nginx.git test-nginx
           cd test-nginx && (sudo cpanm --notest . > build.log 2>&1 || (cat build.log && exit 1)) && cd ..
 
-          wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-openresty.sh
+          wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.2.1/build-apisix-openresty.sh
           chmod +x build-apisix-openresty.sh
           OR_PREFIX=$OPENRESTY_PREFIX ./build-apisix-openresty.sh latest
 


### PR DESCRIPTION
Signed-off-by: tzssangglass <tzssangglass@gmail.com>