### PR TITLE
fix: we don't need to close http_cli after reading chunks failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15"
+          # goreman requires 1.17
+          go-version: "1.17"
 
       - name: get dependencies
         run: sudo apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl


### PR DESCRIPTION
It will be closed by watchcancel method.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>