### PR TITLE
chore: fix CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Name
 
 [resty-etcd](https://github.com/iresty/lua-resty-etcd) Nonblocking Lua etcd driver library for OpenResty, this module supports etcd API v3.
 
-[![Build Status](https://travis-ci.org/api7/lua-resty-etcd.svg?branch=master)](https://travis-ci.org/api7/lua-resty-etcd)
+[![Build Status](https://github.com/api7/lua-resty-etcd/actions/workflows/ci.yml/badge.svg)](https://github.com/api7/lua-resty-etcd/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/iresty/lua-resty-etcd/blob/master/LICENSE)
 
 Table of Contents


### PR DESCRIPTION
The travis-ci had no longer been used, So I changed the badge of the continuous integration’s badge.
Signed-off-by: u5surf <u5.horie@gmail.com>