### PR TITLE
test: fix flaky test

### DIFF
--- a/t/v3/grpc/txn.t
+++ b/t/v3/grpc/txn.t
@@ -133,7 +133,7 @@ checked val as expect: abc
             check_res(etcd, err)
 
             local res, err = etcd:delete("/setnx")
-            check_res(res, err, nil, 200)
+            check_res(res, err)
 
             local res, err = etcd:setnx("/setnx", "aaa")
             check_res(res, err, nil, 200)


### PR DESCRIPTION
delete /setnx may return 404 if `/setnx` is not existed.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>