### PR TITLE
fix: ensure timeout not nil to avoid `attempt to perform arithmetic on a nil value` error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           git clone https://github.com/openresty/test-nginx.git test-nginx
           cd test-nginx && (sudo cpanm --notest . > build.log 2>&1 || (cat build.log && exit 1)) && cd ..
 
-          wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-base.sh
+          wget https://raw.githubusercontent.com/api7/apisix-build-tools/refs/tags/apisix-base/1.21.4.2.2/build-apisix-base.sh
           chmod +x build-apisix-base.sh
           OR_PREFIX=$OPENRESTY_PREFIX ./build-apisix-base.sh latest
 

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -507,6 +507,7 @@ function refresh_jwt_token(self, timeout)
     end
 
     if self.requesting_token then
+        timeout = timeout or self.timeout or 0
         self.sema:wait(timeout)
         if self.jwt_token and now() - self.last_auth_time < 60 * 3 + random(0, 60) then
             return true, nil

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -507,8 +507,8 @@ function refresh_jwt_token(self, timeout)
     end
 
     if self.requesting_token then
-        timeout = timeout or self.timeout or 0
-        self.sema:wait(timeout)
+        local wait_timeout = timeout and timeout or (self.timeout and self.timeout or 0)
+        self.sema:wait(wait_timeout)
         if self.jwt_token and now() - self.last_auth_time < 60 * 3 + random(0, 60) then
             return true, nil
         end

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -507,7 +507,7 @@ function refresh_jwt_token(self, timeout)
     end
 
     if self.requesting_token then
-        local wait_timeout = timeout and timeout or (self.timeout and self.timeout or 0)
+        local wait_timeout = timeout or self.timeout or 0
         self.sema:wait(wait_timeout)
         if self.jwt_token and now() - self.last_auth_time < 60 * 3 + random(0, 60) then
             return true, nil


### PR DESCRIPTION
error logs:
![image](https://github.com/api7/lua-resty-etcd/assets/33000667/16cb6bfc-0de7-46c7-8626-9acfcbfae00a)

The cause of the issue is that in the function `refresh_jwt_token`,  the parameter `timeout` of semaphore wait directly uses the parameter passed by the caller without considering that the `timeout` parameter may be nil. If the caller does not pass the parameter `timeout`, this error will be triggered:

<img width="861" alt="image" src="https://github.com/api7/lua-resty-etcd/assets/33000667/44d592e8-98d4-463e-a6af-f2b9759a639d">

![image](https://github.com/api7/lua-resty-etcd/assets/33000667/d3d6d5e3-51ad-47ec-82af-7a08d65a0f53)

<img width="886" alt="image" src="https://github.com/api7/lua-resty-etcd/assets/33000667/b1d9d107-d974-4026-9ac7-9534233cca26">

The `timeout` passed to the function `refresh_jwt_token` is basically `self.timeout`:

![image](https://github.com/api7/lua-resty-etcd/assets/33000667/2630ad53-a3d1-4418-a79f-d71928227519)
![image](https://github.com/api7/lua-resty-etcd/assets/33000667/8b0ad7a3-d193-466c-9fb3-75caac658fda)
![image](https://github.com/api7/lua-resty-etcd/assets/33000667/35d9c670-20f6-4185-9f42-7187c1a4f75b)

Since the `timeout` passed to the function `refresh_jwt_token` is basically `self.timeout`, we make a judgment on the `timeout` parameter in `refresh_jwt_token`, If it is nil, just use `self.timeout`, if `self.timeout` is nil too, just use 0, to ensure the `timeout` is not nil to avoid the error.


