### PR TITLE
support readdir in batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - version: 3.4.0
             conf: Procfile-single-enable-mtls
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       OPENRESTY_PREFIX: "/usr/local/openresty"
       AUTH_ENDPOINT_V3: "127.0.0.1:12379"
@@ -41,7 +41,7 @@ jobs:
           go-version: "1.17"
 
       - name: get dependencies
-        run: sudo apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl
+        run: sudo apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3-dev libpcre3
 
       - name: Setup Lua
         uses: leafo/gh-actions-lua@v8.0.0

--- a/lib/resty/etcd/utils.lua
+++ b/lib/resty/etcd/utils.lua
@@ -9,6 +9,8 @@ local select        = select
 local ipairs        = ipairs
 local pairs         = pairs
 local type          = type
+local str_char      = string.char
+
 
 
 if not http.tls_handshake then
@@ -124,5 +126,11 @@ local function is_empty_str(input_str)
     return (find(input_str or '', [=[^\s*$]=], "jo"))
 end
 _M.is_empty_str = is_empty_str
+
+--- @param  key string
+--- @return string
+_M.next_key = function(key)
+    return key .. str_char(0)
+end
 
 return _M

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -952,7 +952,8 @@ local function request_chunk(self, method, path, opts, timeout)
     end
 end
 
-
+--- @param  key string
+--- @return string
 local function get_range_end(key)
     if #key == 0 then
         return str_char(0)
@@ -1319,7 +1320,7 @@ function _M.readdir(self, key, opts)
 
     key = utils.get_real_key(self.key_prefix, key)
 
-    attr.range_end = get_range_end(key)
+    attr.range_end = opts and opts.range_end or get_range_end(key)
     attr.revision = opts and opts.revision
     attr.limit        = opts and opts.limit
     attr.sort_order   = opts and opts.sort_order
@@ -1688,6 +1689,9 @@ function _M.rmdir(self, key, opts)
 end
 
 end -- do
+
+_M.rangeend = get_range_end
+_M.nextkey = utils.next_key
 
 
 local implemented_grpc_methods = {

--- a/t/v3/grpc/txn.t
+++ b/t/v3/grpc/txn.t
@@ -88,6 +88,10 @@ __DATA__
             check_res(data, err, "ddd")
         }
     }
+--- request
+GET /t
+--- no_error_log
+[error]
 --- response_body
 checked val as expect: abc
 checked val as expect: ddd
@@ -118,6 +122,10 @@ checked val as expect: ddd
             check_res(data, err, "abc")
         }
     }
+--- request
+GET /t
+--- no_error_log
+[error]
 --- response_body
 checked val as expect: abc
 checked val as expect: abc
@@ -145,6 +153,10 @@ checked val as expect: abc
             check_res(data, err, "aaa", 200)
         }
     }
+--- request
+GET /t
+--- no_error_log
+[error]
 --- response_body
 checked val as expect: aaa
 
@@ -201,6 +213,10 @@ checked val as expect: aaa
             check_res(data, err, '{"k":"ddd"}')
         }
     }
+--- request
+GET /t
+--- no_error_log
+[error]
 --- response_body
 checked val as expect: {"k":"abc"}
 checked val as expect: {"k":"ddd"}

--- a/t/v3/tls.t
+++ b/t/v3/tls.t
@@ -103,7 +103,7 @@ GET /t
 --- no_error_log
 [error]
 --- response_body eval
-qr/18: self signed certificate/
+qr/self-signed certificate/
 
 
 


### PR DESCRIPTION
When using etcd's `cli:readdir`, if the value in this path is too large (by default: exceeding 4MB), you will encounter the 

following error: 

```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8653851 vs. 4194304).
```

Therefore, we need to read this directory in batches. 

``` lua
local cli, _ = etcd.new([option:table])

local res, err
local start_key = '/path/to/dir'
local last_key = start_key
local range_end = cli.rangeend(start_key)
local data = {}
while(1) do
    res, err = cli:readdir(last_key, {
        timeout = 3000,
        range_end = range_end,
        revision = -1,
        limit = 20, -- batch size 
        sort_order = 'ASCEND',
        sort_target = 'KEY',
    })
    -- error handle
    if err or not res then
        break
    end
    -- collect res.body
    table.insert(data, res.body)
    local last_kv_key = res.body.kvs[#res.body.kvs].key
    last_key = cli.nextkey(last_key)
    if not res.body.more then
        break
    end
end

for _, body in ipairs(data) do
    -- handle data
end
```

This commit also fixes some testing bugs in continuous integration, update ci image from ubuntu-20.04 to ubuntu-22.04.
