### PR TITLE
fix(watch): guard against nil http_code on gRPC stream errors (fixes #222)

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -911,11 +911,25 @@ local function request_chunk(self, method, path, opts, timeout)
             body, err = decode_json(chunk)
             if not body then
                 return nil, "failed to decode json body: " .. (err or " unknown")
-            elseif body.error and body.error.http_code >= 500 then
-                -- health_check retry should do nothing here
-                -- and let connection closed to create a new one
-                health_check.report_failure(endpoint.http_host)
-                return nil, endpoint.http_host .. ": " .. body.error.http_status
+            elseif body.error then
+                -- A watch over a gRPC stream can report an error with no HTTP status,
+                -- e.g. {"error":{"grpc_code":14,"message":"...EOF"}} on a transport /
+                -- stream error. The previous `body.error.http_code >= 500` then compared
+                -- nil with a number ("attempt to compare nil with number"), crashing the
+                -- watch coroutine, skipping cancel_watch and leaking watchers on etcd.
+                -- Parse http_code defensively; treat a missing code (transport / stream
+                -- error) or any 5xx as an endpoint failure -> report_failure and let the
+                -- connection close so a fresh one is created. Other errors (e.g. a 4xx
+                -- with an http_code) fall through to the caller as before.
+                local raw = body.error.http_code
+                local http_code = (type(raw) == "number" and raw)
+                                  or (type(raw) == "string" and tonumber(raw)) or nil
+                if http_code == nil or http_code >= 500 then
+                    health_check.report_failure(endpoint.http_host)
+                    return nil, endpoint.http_host .. ": "
+                                .. (body.error.http_status or body.error.message
+                                    or "watch stream error")
+                end
             end
 
             if body.result and body.result.events then


### PR DESCRIPTION
## Problem

A watch over a gRPC stream can surface an error object that has **no HTTP status**.
On a transport / stream error etcd's grpc-gateway returns something like:

```json
{"error":{"grpc_code":14,"message":"error reading from server: EOF"}}
```

The watch read loop checks:

```lua
elseif body.error and body.error.http_code >= 500 then
```

When `http_code` is `nil` this evaluates `nil >= 500`, raising
**`attempt to compare nil with number`** inside the watch coroutine.

## Impact

The error aborts the watch read mid-flight, so `cancel_watch` is skipped and the
**watcher leaks on the etcd side**. A caller that restarts the watch immediately
with no backoff (for example APISIX `config_etcd.lua`'s `run_watch` via
`ngx.timer.at(0, ...)`) then spins in a tight watch-recreate loop. In a production
APISIX 3.x cluster this drove etcd `mvcc_watcher_total` into the millions and
OOM-crashlooped the etcd pods.

## Fix

Parse `http_code` defensively and treat a **missing** code (transport / stream
error) or any **5xx** as an endpoint failure — `report_failure` + return a graceful
error so the connection is closed, rebuilt, and the watcher cancelled properly.
Errors that *do* carry an `http_code` (e.g. a 4xx) keep falling through to the
caller exactly as before.

```lua
local raw = body.error.http_code
local http_code = (type(raw) == "number" and raw)
                  or (type(raw) == "string" and tonumber(raw)) or nil
if http_code == nil or http_code >= 500 then
    health_check.report_failure(endpoint.http_host)
    return nil, endpoint.http_host .. ": "
                .. (body.error.http_status or body.error.message or "watch stream error")
end
```

## Testing

- Verified in production: with this patch applied (on 1.10.6) the
  `compare nil with number` crashes dropped to 0, stream EOFs take the
  graceful-error path, etcd watcher count fell back to ≈ number of streams
  (single digits), and etcd memory went from hitting the limit back to ~40Mi.
- I did **not** add an automated test. The trigger is a transport-level gRPC
  stream EOF mid-watch, which the `Test::Nginx` suite (talking to a real etcd)
  can't reproduce deterministically. Happy to add one if maintainers can point at
  an existing pattern for injecting a malformed / `error`-only watch chunk.

Fixes #222.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of watch stream errors so missing or non-numeric status codes no longer cause failures.
  * Server-side errors are now reported more reliably, with clearer fallback messages when status details are incomplete.
  * Endpoint health is marked more accurately when a watch request fails with a serious error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->