### PR TITLE
feat: release v1.10.7

### DIFF
--- a/rockspec/lua-resty-etcd-1.10.7-0.rockspec
+++ b/rockspec/lua-resty-etcd-1.10.7-0.rockspec
@@ -1,0 +1,34 @@
+package = "lua-resty-etcd"
+version = "1.10.7-0"
+source = {
+   url = "git://github.com/api7/lua-resty-etcd",
+   tag = "v1.10.7",
+}
+
+description = {
+   summary = "Nonblocking Lua etcd driver library for OpenResty",
+   homepage = "https://github.com/api7/lua-resty-etcd",
+   license = "Apache License 2.0",
+   maintainer = "Yuansheng Wang <membphis@gmail.com>"
+}
+
+dependencies = {
+   "api7-lua-resty-http = 0.2.2-0",
+   "lua-protobuf = 0.4.1",
+   "luafilesystem = 1.7.0-2",
+   "penlight = 1.9.2-1",
+   "lua-typeof = 0.1"
+}
+
+build = {
+   type = "builtin",
+   modules = {
+    ["resty.etcd"] = "lib/resty/etcd.lua",
+    ["resty.etcd.v3"] = "lib/resty/etcd/v3.lua",
+    ["resty.etcd.proto"] = "lib/resty/etcd/proto.lua",
+    ["resty.etcd.utils"] = "lib/resty/etcd/utils.lua",
+    ["resty.etcd.serializers.json"] = "lib/resty/etcd/serializers/json.lua",
+    ["resty.etcd.serializers.raw"] = "lib/resty/etcd/serializers/raw.lua",
+    ["resty.etcd.health_check"] = "lib/resty/etcd/health_check.lua",
+   }
+}


### PR DESCRIPTION
Release v1.10.7.

Adds `rockspec/lua-resty-etcd-1.10.7-0.rockspec` (tag `v1.10.7`). Merging this to master triggers the `Release` workflow, which creates the GitHub release/tag and uploads the rockspec to LuaRocks.

### Included since v1.10.6
- fix(watch): do not drop events when a read carries multiple responses (#224) — when etcd coalesces multiple watch responses into a single body read and the last one is event-less (e.g. a progress notification), events from earlier responses are no longer silently dropped. Required by the APISIX `progress_notify` change.

> [!NOTE]
> Merge with **squash** so the commit message stays `feat: release v1.10.7`; the release workflow's version regex requires the `feat: release v` prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a package specification for `lua-resty-etcd` version 1.10.7-0.
  * Defined package metadata, runtime dependencies, source information, and OpenResty module mappings for installation and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->